### PR TITLE
Corrected 404 /wiki/FAQ link on Homepage

### DIFF
--- a/site/themes/citra-bs-theme/layouts/partials/jumbotron.html
+++ b/site/themes/citra-bs-theme/layouts/partials/jumbotron.html
@@ -33,7 +33,7 @@
 
     <div class="row">
       <div id="carousel-description" class="col-md-12">
-        <b>Citra</b> is an open-source emulator for the Nintendo 3DS capable of playing many of your favorite games. <a href="/wiki/FAQ/">Learn More.<a/>
+        <b>Citra</b> is an open-source emulator for the Nintendo 3DS capable of playing many of your favorite games. <a href="/wiki/faq/">Learn More.<a/>
       </div>
 
       <div class="col-md-12 jumbotron-action" id="jumbotron-download" style = "padding-top: 6%; padding-bottom: 2%; text-align: center;">


### PR DESCRIPTION
This corrects the broken FAQ link on the homepage Jumbotron "Learn More"