### PR TITLE
Quickfix: Left align table cells by default

### DIFF
--- a/src/scss/citra-theme.scss
+++ b/src/scss/citra-theme.scss
@@ -231,6 +231,10 @@ a:hover {
   image-rendering: pixelated;
 }
 
+tbody td {
+  text-align: left;
+}
+
 /* User Profiles - Flarum Integration */
 .profile-avatar {
   border-radius: 24px;


### PR DESCRIPTION
This unifies formatting in blog post tables and left aligns text in non-header columns.

This does, as far as I can see, affect current tables outside of blog entries.