### PR TITLE
Remove the "The" prefix from titles in the data attribute

### DIFF
--- a/site/themes/citra-bs-theme/layouts/game/list.html
+++ b/site/themes/citra-bs-theme/layouts/game/list.html
@@ -63,7 +63,7 @@
 						<td class="col-md-1 icon">
 							<img src="/images/game/icons/{{ .File.BaseFileName }}.png" />
 						</td>
-						<td class="col-md-6 title" data-title="{{ .Params.title }}">
+						<td class="col-md-6 title" data-title="{{ strings.TrimPrefix "The " .Params.title }}">
 							<a href="{{ .Permalink }}">{{ .Params.title }}</a>
 						</td>
 						<td class="col-md-1 type" data-type="{{ $type.name }}">


### PR DESCRIPTION
This fixes games like The Legend of Zelda being sorted under "T" instead of "L" on the compatibility list.