### PR TITLE
Re-add section id headers

### DIFF
--- a/site/themes/citra-bs-theme/layouts/game/list.html
+++ b/site/themes/citra-bs-theme/layouts/game/list.html
@@ -53,10 +53,9 @@
 			{{ range .Data.Pages.GroupByParam "section_id" }}
 
 				{{ range .Pages }}
-					{{- $key := substr .Params.title 0 1 }}
 					{{- $rating := index .Site.Data.compatibility .Params.compatibility }}
 					{{- $type := index .Site.Data.gameTypes (.Params.game_type | default "3ds") }}
-					<tr data-key="{{ $key }}">
+					<tr data-key="{{ .Params.section_id }}">
 						<td class="hidden listing-metadata">
 							<span>{{ .Params.title }} {{ $type.name }} {{ $rating.name }} {{ dateFormat "January 2, 2006" .Params.testcase_date }}</span>
 						</td>

--- a/src/scss/citra-theme.scss
+++ b/src/scss/citra-theme.scss
@@ -341,6 +341,18 @@ tbody td {
   margin: 0 20px;
 }
 
+/* Used for showing section id at the start of each game section */
+.key:after {		
+  content: attr(data-key);
+  position: absolute;
+  left: -10px;
+  font-family: Dosis,"Helvetica Neue",Helvetica,Arial,sans-serif;
+  text-transform: lowercase;
+  color: #888;
+  margin: 15px 0;
+  font-size: 24px;
+}
+
 /* Downloads */
 #updater-view, #manual-view, .dl-updater-button, #dl-unknown, #dl-autodetect {
   display: none;


### PR DESCRIPTION
Fix regression introduced by #45/#46 that removed the section id headers ([see here](https://github.com/citra-emu/citra-web/pull/46/files#diff-0431ddf85bbf07fff323754f86096c3cL352)).

This also changes the title key from the first letter of the title to the proper section id.

See #32 for how it used to look like.