### PR TITLE
Add callout for Hugo documents

### DIFF
--- a/site/themes/citra-bs-theme/layouts/shortcodes/callout.html
+++ b/site/themes/citra-bs-theme/layouts/shortcodes/callout.html
@@ -1,0 +1,3 @@
+<div class="alert alert-info">
+    {{ .Inner }}
+</div>


### PR DESCRIPTION
Example usage:
```markdown
<!-- If this was placed at the top of the document, we don't want Hugo previewing the callout: -->
<!--more-->

{{% callout %}}
We're all terribly sorry for the delay in getting this progress
report out the door, but our main technical writer [anodium](https://github.com/anodium),
was just a bit busy surviving both Hurricane Irma and Maria. Although she's a
trooper and claims it's not an excuse for the delay, we find that her personal
safety is a tad more important. We're all glad that she's safe and sound, and in
a state where she can keep pumping out quality articles for Citra!
{{% /callout %}}
```
turns into:
![idea64-06-11-2017_23-29-19](https://user-images.githubusercontent.com/1404334/32441159-5fc56e16-c34a-11e7-94dc-4b4454fbe294.png)
