### PR TITLE
Reverse order of multiple test cases

### DIFF
--- a/scripts/games/app.js
+++ b/scripts/games/app.js
@@ -121,6 +121,9 @@ function processGame(game) {
     var model = toml.parse(fs.readFileSync(`${fsPathCode}/${game}/game.dat`, 'utf8'));
     let currentDate = new Date();
     model.date = `${currentDate.toISOString()}`;
+    
+    // Reverse the order of the testcases array, so that the newest ones are displayed first
+    model.testcases = model.testcases.reverse();
 
     // SHORTCUTS BLOCK
     // Parse testcase information out of the dat to reinject as shortcut values.


### PR DESCRIPTION
Potential fix for test cases showing up in reverse order on game wiki pages, and the oldest test case being displayed as the most recent rating.

Ideally, Hugo would read the array backwards, but I couldn't find a way to do it. 

Closes citra-emu/citra-games-wiki#153