### PR TITLE
Change "Games" to "Compatibility"

### DIFF
--- a/site/themes/citra-bs-theme/layouts/_default/baseof.html
+++ b/site/themes/citra-bs-theme/layouts/_default/baseof.html
@@ -77,7 +77,7 @@
 
 		        <div class="col-md-2">
 		            <h1>Documentation</h1>
-		            <a href="/game/">Games</a>
+		            <a href="/game/">Compatibility</a>
 		            <a href="/wiki/home/">Wiki</a>
 		            <a href="/wiki/faq/">FAQ</a>
 		        </div>


### PR DESCRIPTION
There seems to be a lot of confusion about what the "Games" tab in the header is for. Users frequently ask why they cannot download games from this portion of the site, changing "Games" to "Compatibility" may alleviate this.
![image](https://user-images.githubusercontent.com/28246325/39326567-11f1c972-495b-11e8-9b5d-ff2da1579b13.png)
