### PR TITLE
Remove workaround for upstream GitHub pages deploy bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ script:
   - gulp all --production
 deploy:
  provider: pages
- edge:
-   branch: pages-ivar-set
  skip_cleanup: true
  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
  local_dir: build


### PR DESCRIPTION
As per https://github.com/travis-ci/travis-ci/issues/9312, an upstream deploy bug relating to a broken Ruby gem has been fixed, and we are safe to remove the specific bugfix branch we were using previously, as introduced by https://github.com/citra-emu/citra-web/commit/3e2df0c726b3bfdeb58a58098a0388807535cfb2