### PR TITLE
Improve help pages

### DIFF
--- a/site/content/help/_index.md
+++ b/site/content/help/_index.md
@@ -2,6 +2,6 @@
 title = "Help"
 +++
 
-User documentation on how to use Citra and frequently asked questions can be found here. 
+User documentation on how to use Citra and frequently asked questions can be found here. Information for developers can be found on the [developer wiki](https://citra-emu.org/wiki/faq/).
 
-If you would like more information on a subject, please contact our moderation team on Discord.
+If you would like more information on a subject, or you're having trouble, support is offered in our [Discord server](https://citra-emu.org/discord/).

--- a/site/themes/citra-bs-theme/layouts/help/single.html
+++ b/site/themes/citra-bs-theme/layouts/help/single.html
@@ -1,0 +1,9 @@
+{{ define "main" }}
+  <h1>
+    {{ .Title }}
+  </h1>
+
+  <div class="entry-content">
+    {{ .Content }}
+  </div>
+{{ end }}

--- a/site/themes/citra-bs-theme/layouts/help/summary.html
+++ b/site/themes/citra-bs-theme/layouts/help/summary.html
@@ -1,0 +1,6 @@
+<div class="col-md-12">
+  <div>
+      <h2><a href="{{ .RelPermalink }}" >{{ .Title }}</a></h2>
+      <p>{{ .Description }}</p>
+  </div>
+</div>


### PR DESCRIPTION
This pull request improves the look of the user documentation:
- Wording of the index page has been improved, and now links to the appropriate pages. I've tried for [`ref` URLs](https://gohugo.io/content-management/cross-references/), but I wasn't able to get them to work for the developer wiki link, so I have made them both hardcoded links.
- The summaries of help pages now no longer include the default summary, because it didn't look good for them.
- The contents of the help pages are now rendered as blog entries so that they can benefit from blog CSS. One particular instance of this being useful is that text in figures in blog entries [are centered](https://github.com/citra-emu/citra-web/blob/master/src/scss/citra-theme.scss#L316-L319). I feel this is the best solution as the blog and help articles will likely have similar requirements moving forward.

Preview of the new help index:
![image](https://user-images.githubusercontent.com/13039555/63216364-f02b2c00-c101-11e9-8d01-b597a83e5577.png)