### PR TITLE
Improve shortcodes

### DIFF
--- a/site/content/entry/citra-progress-report-2017-september.md
+++ b/site/content/entry/citra-progress-report-2017-september.md
@@ -15,14 +15,14 @@ There's also been many changes this month that improve the speed of emulation ac
 the board, on top of the usual improvements in accuracy and features. And because
 of that, I've dubbed this month #Speedtember. Let's dive right in.
 
-{{% callout %}}
+{{% alert info %}}
 Hello everyone! We're all terribly sorry for the delay in getting this progress
 report out the door, but our main technical writer [anodium](https://github.com/anodium),
 was just a bit busy surviving both Hurricane Irma and Maria. Although she's a
 trooper and claims it's not an excuse for the delay, we find that her personal
 safety is a tad more important. We're all glad that she's safe and sound, and in
 a state where she can keep pumping out quality articles for Citra!
-{{% /callout %}}
+{{% /alert %}}
 
 ## [Switchable Page Tables](https://github.com/citra-emu/citra/pull/2952) by [MerryMage](https://github.com/MerryMage)
 

--- a/site/themes/citra-bs-theme/layouts/shortcodes/alert.html
+++ b/site/themes/citra-bs-theme/layouts/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-{{.Get 0}}">
+  {{ .Inner }}
+</div>

--- a/site/themes/citra-bs-theme/layouts/shortcodes/callout.html
+++ b/site/themes/citra-bs-theme/layouts/shortcodes/callout.html
@@ -1,3 +1,0 @@
-<div class="alert alert-info">
-    {{ .Inner }}
-</div>

--- a/site/themes/citra-bs-theme/layouts/shortcodes/figure.html
+++ b/site/themes/citra-bs-theme/layouts/shortcodes/figure.html
@@ -13,7 +13,7 @@
     {{ with .Get "title" }}
     <figcaption>
         <h4>
-            {{ . }}
+            {{ . | markdownify }}
         </h4>
     </figcaption>
     {{ end }}

--- a/site/themes/citra-bs-theme/layouts/shortcodes/sidebyside.html
+++ b/site/themes/citra-bs-theme/layouts/shortcodes/sidebyside.html
@@ -23,7 +23,7 @@
                 {{ end }}
                 <figcaption>
                     <h4>
-                        {{ $.Scratch.Get "title" }}
+                        {{ $.Scratch.Get "title" | markdownify }}
                     </h4>
                 </figcaption>
             </figure>

--- a/site/themes/citra-bs-theme/layouts/shortcodes/sidebyside.html
+++ b/site/themes/citra-bs-theme/layouts/shortcodes/sidebyside.html
@@ -9,6 +9,7 @@
     {{ range $figure := $figures }}
         {{ $.Scratch.Set "src" (index (split $figure "=") 0) }}
         {{ $.Scratch.Set "title" (index (split $figure "=") 1) }}
+        {{ $.Scratch.Set "link" (index (split $figure "=") 2) }}
         <div class="theme-table-image col-sm-{{ $.Scratch.Get "size" }}">
             <figure style="padding: 0px;">
                 {{ if eq $type "gifv" }}
@@ -20,6 +21,10 @@
                     </div>
                 {{ else if eq $type "image" }}
                     <img src="{{ printf "%s%s" $path ($.Scratch.Get "src") }}" alt="{{ $.Scratch.Get "title" }}" />
+                {{ else if eq $type "imagelink" }}
+                    <a href="{{ $.Scratch.Get "link" }}" style="border-bottom-style: none;" >
+                        <img src="{{ printf "%s%s" $path ($.Scratch.Get "src") }}" alt="{{ $.Scratch.Get "title" }}" />
+                    </a>
                 {{ end }}
                 <figcaption>
                     <h4>


### PR DESCRIPTION
Commit-by-commit review suggested.

This PR makes a few changes to the shortcodes:
- A new `alert` shortcode has been added, for future use with articles (both blogs, and help). `callout` has been removed, and the instance of it being used has been adjusted accordingly. This is what it looks like in action:
```md
{{% alert warning %}}
Ensure that you have the latest version of GodMode9 installed! Otherwise, odd issues may come up while dumping.
{{% /alert %}}
```
![image](https://user-images.githubusercontent.com/13039555/63217099-d859a500-c10d-11e9-827e-6742b999d2b7.png)
- The `figure` and `sidebyside` shortcodes now properly process Markdown in their captions.
- The `sidebyside` shortcode now has a `imagelink` mode, where an image can also be a clickable link. Here's an example showing off both this, and the last change:
```md
{{< sidebyside "imagelink" "/images/help/dumping/games/"
    "physical-icon.png=### [Dumping Game Cartridges](#dumping-game-cartridges)=#dumping-game-cartridges"
    "digital-icon.png=### [Dumping Installed Games](#dumping-installed-games)=#dumping-installed-games" >}}
```
![image](https://user-images.githubusercontent.com/13039555/63217136-7f3e4100-c10e-11e9-8350-56a0352d51a9.png)
This may not be the cleanest or most proper syntax, but this is the easiest way to do it, which matters given the impending migration.