### PR TITLE
Update Custom Textures help page to remove the WIP message

### DIFF
--- a/site/content/help/feature/custom-textures/index.md
+++ b/site/content/help/feature/custom-textures/index.md
@@ -3,10 +3,7 @@ title = "Custom Textures"
 description = "Custom texture features for displaying custom graphics packs."
 +++
 
-**Note: This feature is currently still WIP (Work-in-progress)!**
-
-Texture dumping and replacement have been implemented for Citra, by [**Khang06**](https://github.com/khang06). <br>
-For more details, see [**PR #4868**](https://github.com/citra-emu/citra/pull/4868).
+Citra has the ability to dump game textures and load custom texture packs. Currently, only **`.PNG`** files are supported, but it is expected that more formats will come in the future.
 
 ## Instructions for dumping textures
 


### PR DESCRIPTION
This is not WIP anymore. Also changed the language to make it more consistent with other help articles (starting with something like `Citra can ...`)