### PR TITLE
Allow searching for "pokemon" and "pokedex"

### DIFF
--- a/site/themes/citra-bs-theme/layouts/game/list.html
+++ b/site/themes/citra-bs-theme/layouts/game/list.html
@@ -108,6 +108,11 @@
 			$("#search-box").val("");
 			list.search();
 		}
+		
+		document.getElementById('search-box').addEventListener('input', function(e) {
+			var searchBox = e.target;
+			searchBox.value = searchBox.value.replace(/pokemon/gi, 'pokémon').replace(/pokedex/gi, 'pokédex');
+		}, true);
 
 		var options = {
 			valueNames: [


### PR DESCRIPTION
Allow searching for "pokemon" and "pokedex" (with no accent) on the games compatibility page by dynamically replacing those terms (since they have no results anyway.)

This is definitely hacky, but seems to work pretty well. If we were more in control of the search index (currently built by the list library), that would probably be the better place to resolve this.

The very first thing I tried do when I got to the citra site was search for pokemon compatibility, so I'm sure that this must affect a lot of people :)