### PR TITLE
Update the Apple silicon notice

### DIFF
--- a/site/content/download.md
+++ b/site/content/download.md
@@ -30,7 +30,7 @@ The Citra updater provides a easy interface to install, update and manage Citra.
  </style>
  
 <div class="alert">
-  Notice: Citra does NOT support Apple silicon SoC (ARM) MacOS devices. Our Mac builds may run through Rosetta, but you WILL encounter various issues that we won't provide support for. We may eventually support M1 Macs, but not at this time.
+  Notice: Citra does NOT support Apple silicon (M1/M2) MacOS devices. Our Mac builds may run through Rosetta, but you WILL encounter various issues that we won't provide support for. We may eventually support M1 Macs, but not at this time.
 </div>
 <br />
  

--- a/site/content/download.md
+++ b/site/content/download.md
@@ -30,7 +30,7 @@ The Citra updater provides a easy interface to install, update and manage Citra.
  </style>
  
 <div class="alert">
-  Notice: Citra does NOT support Macs with M1 chipsets. Our Mac builds may run through Rosetta, but you WILL encounter various issues that we won't provide support for. We may eventually support M1 Macs, but not at this time.
+  Notice: Citra does NOT support Apple silicon SoC (ARM) MacOS devices. Our Mac builds may run through Rosetta, but you WILL encounter various issues that we won't provide support for. We may eventually support M1 Macs, but not at this time.
 </div>
 <br />
  


### PR DESCRIPTION
Since there are M2 chipsets as well now, and ofcourse we've already had someone on the forums say that they didn't think the notice applied to them since it said "M1", and not "M2". ~~Makes me wonder if I should specifically mention M1 and M2 as well...~~
I included it.