### PR TITLE
Change font size for blog post entry headers.

### DIFF
--- a/site/assets/scss/citra-theme.scss
+++ b/site/assets/scss/citra-theme.scss
@@ -281,7 +281,7 @@ tbody td {
   left: 0;
 }
 .entry-embed > header > h1 {
-  font-size: 48px;
+  font-size: 46px;
   color: #FF8E03;
   background-color: #fff;
   margin: 0px !important;


### PR DESCRIPTION
At the moment, the font size is just a little too big for the Mega Progress Reports, to the point where it starts cutting off the banner and looking weird. 
![image](https://user-images.githubusercontent.com/86921268/226189489-0007a061-c44c-4b04-a02d-423f7482605a.png)

This is fixed by changing the size from 48px to 46px (number suggested by liushuyu on Discord a few weeks back)
![image](https://user-images.githubusercontent.com/86921268/226189562-2f993f6d-38c6-4fae-9271-b917969b56f1.png)
