### PR TITLE
Remove Apple Silicon notice from downloads page

### DIFF
--- a/site/content/download.md
+++ b/site/content/download.md
@@ -19,20 +19,6 @@ The Citra updater provides a easy interface to install, update and manage Citra.
  this is likely what you are looking for.
 <br />
 <br />
-
-<style>
- .alert {
-  padding: 20px;
-  background-color: #ff8e03;
-  color: white;
-  margin-bottom: 15px;
-}
- </style>
- 
-<div class="alert">
-  Notice: Citra does NOT support Apple silicon (M1/M2) MacOS devices. Our Mac builds may run through Rosetta, but you WILL encounter various issues that we won't provide support for. We may eventually support M1 Macs, but not at this time.
-</div>
-<br />
  
 <div class="text-center">
 <i id="dl-autodetect">Autodetected platform: XYZ</i>


### PR DESCRIPTION
Now that Vulkan is added to Canary, Apple Silicon (M1/M2) devices work in Citra. This notice is now redundant.